### PR TITLE
Add allow-root for wp-core-download command

### DIFF
--- a/wpmu-subdirectory.dev/vvv-init.sh
+++ b/wpmu-subdirectory.dev/vvv-init.sh
@@ -20,7 +20,7 @@ if [[ ! -d /srv/www/wpmu-subdirectory ]]; then
 	cd /srv/www/wpmu-subdirectory
 
 	echo "Downloading WordPress Multisite Subdirectory Stable, see http://wordpress.org/"
-	wp core download
+	wp core download --allow-root
 
 	echo "Configuring WordPress Multisite Subdirectory Stable..."
 	wp core config --dbname=wpmu_subdirectory --dbuser=wp --dbpass=wp --quiet --extra-php --allow-root <<PHP

--- a/wpmu-subdomain.dev/vvv-init.sh
+++ b/wpmu-subdomain.dev/vvv-init.sh
@@ -20,7 +20,7 @@ if [[ ! -d /srv/www/wpmu-subdomain ]]; then
 	cd /srv/www/wpmu-subdomain
 
 	echo "Downloading WordPress Multisite Subdomain Stable, see http://wordpress.org/"
-	wp core download
+	wp core download --allow-root
 
 	echo "Configuring WordPress Multisite Subdomain Stable..."
 	wp core config --dbname=wpmu_subdomain --dbuser=wp --dbpass=wp --quiet --extra-php --allow-root <<PHP


### PR DESCRIPTION
Provisioning failed on my machine because `wp core download` lacked the `allow-root` parameter, which causes next steps to fail as well.